### PR TITLE
Entity Relation Diagram

### DIFF
--- a/ERD.dot
+++ b/ERD.dot
@@ -16,8 +16,6 @@ digraph ER {
         Round
         Pool
         Brother
-        User
-        Vote
 
     // Relations
         node [style=filled fillcolor=lightgrey]
@@ -34,9 +32,6 @@ digraph ER {
             
             Brother -> "Pool Presence"
             Pool -> "Pool Presence"
-
-            "Pool Presence" -> Vote
             
             Round -> Pool
-            User -> Vote
 }

--- a/ERD.dot
+++ b/ERD.dot
@@ -1,0 +1,41 @@
+digraph ER {
+    // General config
+        layout=dot
+        nodesep = "1"
+        ranksep = "1"
+        edge [labelfontsize = 16 labeldistance = 1.5]
+
+        label = "Entity Relation Diagram\n\n"
+        labelloc=top
+        fontsize=20
+        pad = 0.5
+
+    // Entities
+        node [shape=box]
+        BBB
+        Round
+        Pool
+        Brother
+        User
+        Vote
+
+    // Relations
+        node [shape=diamond style=filled fillcolor=lightgrey]
+        "Pool Presence"
+
+        // one to one
+            edge [arrowhead = none]
+
+        // one to many
+            edge [taillabel = "1" headlabel = "n"]
+            BBB -> Round
+            BBB -> Brother
+            
+            Brother -> "Pool Presence"
+            Pool -> "Pool Presence"
+
+            "Pool Presence" -> Vote
+            
+            Round -> Pool
+            User -> Vote
+}

--- a/ERD.dot
+++ b/ERD.dot
@@ -20,7 +20,7 @@ digraph ER {
         Vote
 
     // Relations
-        node [shape=diamond style=filled fillcolor=lightgrey]
+        node [style=filled fillcolor=lightgrey]
         "Pool Presence"
 
         // one to one
@@ -29,7 +29,8 @@ digraph ER {
         // one to many
             edge [taillabel = "1" headlabel = "n"]
             BBB -> Round
-            BBB -> Brother
+            BBB -> Participation
+            Brother -> Participation
             
             Brother -> "Pool Presence"
             Pool -> "Pool Presence"


### PR DESCRIPTION
The diagram is being made with Graphviz, as it will be easier to version control the document.

The diagram intentionally doesn't include fields for the relations. Maybe we'll include it later, but IMO it makes harder to visualize the entities and its relations.

The rendered graph is:

![erd](https://user-images.githubusercontent.com/34381457/120899051-26ea7300-c604-11eb-8a78-18618155303e.png)

Related to #1 